### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This bot is built with Node.js and NPM.  Install by running `npm install` in the
 ## Permissions & Config
 - This bot uses a Google service account to authenticate.  The parameters `clientEmail` and `gPrivateKey` all come from the service account.  The service account needs read access to all spreadsheets used in the bot  but does not need write access (except for the meta-spreadsheet). Be sure to share the spreadsheet with `clientEmail`).
 - `spreadsheetId` is the meta-Google Sheet
-  - Make a copy of this spreadsheet: https://docs.google.com/spreadsheets/d/12i3hIWm51guQhjFtrHpN22nvIUmJRndj1xZqrp3o7xc/edit#gid=0 and add the service account's email address as an editor.
+  - Make a copy of this spreadsheet: https://docs.google.com/spreadsheets/d/1jgbRFTSooaNEFbDvADdP_cyEOvD-WA2vhJDgjbka6Ns/edit#gid=0 and add the service account's email address as an editor.
 - If your Google Domain setup restricts document access to only your domain, you will need to do some extra steps:
   1. Enable your service account for "Show Domain-Wide Delegation" (check the box in the [GCP console](https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project) )
   2. In your [domain admin console](https://admin.google.com/) go to Security -> API Console -> Manage Domain Wide Delegation

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "deploy": "claudia create --region us-west-1 --handler index.handler --deploy-proxy-api --timeout 900;",
     "destroy": "claudia destroy",
-    "test": "claudia test-lambda",
+    "test": "claudia test-lambda --event test-event.json",
     "update": "claudia update"
   },
   "files": [

--- a/sheetbot.js
+++ b/sheetbot.js
@@ -107,8 +107,13 @@ const algorithms = {
   },
   'weekdays_after_topdate': (rows, filter, date) => {
     // get the date from the first row, then just count each weekday
-    const firstDate = (new Date(rows[0][0]));
-    const today = (date ? new Date(date) : new Date());
+    let firstDate = new Date(rows[0][0]);
+    let today = date ? new Date(date) : new Date();
+
+    // Convert to UTC and zero time to do calculations correctly
+    firstDate = Date.UTC(firstDate.getFullYear(), firstDate.getMonth(), firstDate.getDate(), 0, 0, 0, 0);
+    today = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
+
     const daysSince = Math.ceil((today - firstDate) / (1000 * 60 * 60 * 24));
     const weeksSince = parseInt(daysSince / 7);
     const rowIndex = (weeksSince * 5) + (daysSince % 7);

--- a/sheetbot.js
+++ b/sheetbot.js
@@ -81,7 +81,7 @@ const algorithms = {
         const date = (new Date(rows[i][0])).toDateString();
         if (date == today && filter(rows[i])) {
           return rows[i];
-        } else if (date > today) {
+        } else if (new Date(date) > new Date(today)) {
           if (i && filter(rows[i-1])) {
             return rows[i-1];
           } else {

--- a/test-event.json
+++ b/test-event.json
@@ -1,0 +1,3 @@
+{
+  "schedule": "morning_9amET"
+}


### PR DESCRIPTION
- The change in `README.md` updates the link of the spreadsheet template to one where everyone on the Tech team has Edit permission. Everyone on the Tech team only had Read permission to the old link.
- The change on line 84 in `sheetbot.js` fixes the comparison of 2 dates. `date` and `today` were previously cast to strings to get rid of the time when comparing equality, and need to be cast back to date objects to compare greater than/less than
- The change on lines 110-116 in `sheetbot.js` converts dates to UTC and zeroes out the time to correctly calculate the difference in days further below. Without this conversion, there is the possibility of an off-by-one discrepancy
- The changes in `package.json` and `test-event.json` allow for something to actually run when calling `npm run test`. Without this change, you will always get the message `no matched event types` when running `npm run test`
https://github.com/MoveOnOrg/row-bot/blob/dde3de3f85548ec4b97b0c44f6181501cf8e4b4e/README.md?plain=1#L115-L116